### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/CLDR/List.pm
+++ b/lib/CLDR/List.pm
@@ -1,4 +1,4 @@
-class CLDR::List is rw;
+unit class CLDR::List is rw;
 
 constant @placeholders = <{0} {1}>;
 constant %patterns = { # TODO: update with full CLDR data


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
